### PR TITLE
Revert "pydoc-markdown v4.3.0"

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pydoc-markdown" %}
-{% set version = "4.3.0" %}
+{% set version = "4.1.6" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pydoc-markdown-{{ version }}.tar.gz
-  sha256: 5593c454df8d670a6b618270133c81236a41bd34ac6df34667c83e9d76767101
+  sha256: 71538a7a15a4a48af5b7215eb9b5b801e1ff27ad7aa07d0fb2a2ea626d561958
 
 build:
   number: 0


### PR DESCRIPTION
Reverts conda-forge/pydoc-markdown-feedstock#3